### PR TITLE
added CreateService method to the MetadataService

### DIFF
--- a/apex-mdapi/src/classes/MetadataService.cls
+++ b/apex-mdapi/src/classes/MetadataService.cls
@@ -13189,6 +13189,15 @@ public class MetadataService {
         private String[] apex_schema_type_info = new String[]{SOAP_M_URI,'true','false'};
         private String[] field_order_type_info = new String[]{'active','adjustmentsSettings','displayedCategoryApiNames','forecastRangeSettings','forecastedCategoryApiNames','forecastingDateType','hasProductFamily','isAmount','isAvailable','isQuantity','managerAdjustableCategoryApiNames','masterLabel','name','opportunityListFieldsLabelMappings','opportunityListFieldsSelectedSettings','opportunityListFieldsUnselectedSettings','opportunitySplitName','ownerAdjustableCategoryApiNames','quotasSettings','territory2ModelName'};
     }
+
+    public static MetadataService.MetadataPort createService()
+	{ 
+		MetadataService.MetadataPort service = new MetadataService.MetadataPort();
+		service.SessionHeader = new MetadataService.SessionHeader_element();
+		service.SessionHeader.sessionId = UserInfo.getSessionId();
+		return service;		
+	}
+    
     public class MetadataPort {
         public String endpoint_x = URL.getOrgDomainUrl().toExternalForm() + '/services/Soap/m/42.0';
         public Map<String,String> inputHttpHeaders_x;


### PR DESCRIPTION
Added method that is used in examples, but isn't in the MetadataService. Now it's possible to use the CreateService  that is referenced in the README as well as in the examples file